### PR TITLE
developmentブランチへのプルリクエスト時にCIワークフローが動作するように設定を変更

### DIFF
--- a/.github/workflows/ci-document-template-build.yml
+++ b/.github/workflows/ci-document-template-build.yml
@@ -3,7 +3,7 @@ name: ドキュメントテンプレートのビルド
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, development]
     paths:
       # ドキュメントの英語名を以下 2 行に設定します。
       - ".github/workflows/ci-document-template-build.yml"

--- a/.github/workflows/ci-lint-documents.yml
+++ b/.github/workflows/ci-lint-documents.yml
@@ -2,7 +2,7 @@ name: ドキュメントのLint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, development]
     paths:
       - "docs/**"
       - ".github/workflows/ci-lint-documents.yml"


### PR DESCRIPTION
## この Pull request で実施したこと

ドキュメントのLintとビルドを行うCIワークフローが、developmentブランチへのプルリクエスト時にも動作するよう設定を変更します。

## この Pull request では実施していないこと

mainブランチへのプルリクエスト時にも、変わらずCIワークフローがトリガーするままとします。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし