### PR TITLE
リリースノートの自動生成設定を追加

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  categories:
+    - title: ':newspaper: Features'
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - bug
+          - dependencies
+          - internal improvement
+          - release
+    - title: ':wrench: Bug fixes'
+      labels:
+        - bug
+    - title: ':label: :green_circle: GtiHub Actions task dependencies'
+      labels:
+        - CI/CD
+    - title: ':label: :white_circle: npm package dependencies'
+      labels:
+        - npm
+    - title: ':label: Other dependencies'
+      labels:
+        - dependencies
+      exclude:
+        labels:
+          - CI/CD
+          - npm
+    - title: ':lollipop: improvements in development'
+      labels:
+        - internal improvement


### PR DESCRIPTION
## この Pull request で実施したこと

リリースノートを自動生成する際の構成設定を追加しました。
機能更新、不具合修正、依存関係の更新が別々のセクションに表示できるようにしました。
またdevelopmentブランチからmainブランチへのマージを行うプルリクエストを、リリースノートに表示しないようにしました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし