### PR TITLE
dependencies(npm): bump npm-run-all2 from 7.0.1 to 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "marked-admonition-extension": "^0.0.4",
                 "marked-katex-extension": "^5.1.3",
                 "md-to-pdf": "^5.2.4",
-                "npm-run-all2": "^7.0.1",
+                "npm-run-all2": "^7.0.2",
                 "sudachi-synonyms-dictionary": "^14.0.0",
                 "textlint": "^14.4.0",
                 "textlint-filter-rule-comments": "^1.2.2",
@@ -2185,11 +2185,10 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -5806,14 +5805,13 @@
             }
         },
         "node_modules/npm-run-all2": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-7.0.1.tgz",
-            "integrity": "sha512-Adbv+bJQ8UTAM03rRODqrO5cx0YU5KCG2CvHtSURiadvdTjjgGJXdbc1oQ9CXBh9dnGfHSoSB1Web/0Dzp6kOQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-7.0.2.tgz",
+            "integrity": "sha512-7tXR+r9hzRNOPNTvXegM+QzCuMjzUIIq66VDunL6j60O4RrExx32XUhlrS7UK4VcdGw5/Wxzb3kfNcFix9JKDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^6.2.1",
-                "cross-spawn": "^7.0.3",
+                "cross-spawn": "^7.0.6",
                 "memorystream": "^0.3.1",
                 "minimatch": "^9.0.0",
                 "pidtree": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "marked-admonition-extension": "^0.0.4",
         "marked-katex-extension": "^5.1.3",
         "md-to-pdf": "^5.2.4",
-        "npm-run-all2": "^7.0.1",
+        "npm-run-all2": "^7.0.2",
         "sudachi-synonyms-dictionary": "^14.0.0",
         "textlint": "^14.4.0",
         "textlint-filter-rule-comments": "^1.2.2",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file. The change involves updating the version of the `npm-run-all2` package to ensure compatibility and potentially fix bugs.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R18): Updated the `npm-run-all2` package from version `^7.0.1` to `^7.0.2`.