### PR TITLE
VS Codeのtextlint向け拡張機能を更新する

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
         "yzhang.markdown-all-in-one",
         "davidanson.vscode-markdownlint",
         "shuworks.vscode-table-formatter",
-        "taichi.vscode-textlint",
+        "3w36zj6.textlint",
         "streetsidesoftware.code-spell-checker"
     ]
 }


### PR DESCRIPTION
## この Pull request で実施したこと

`taichi.vscode-textlint` が非推奨となったため、 `3w36zj6.textlint` に移行します。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし